### PR TITLE
Normalize frontend auth response handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from './hooks/useAuth'
 import Layout from './components/Layout'

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
-import { LogOut, User, Settings } from 'lucide-react'
+import { LogOut, User } from 'lucide-react'
 
 interface LayoutProps {
   children: React.ReactNode

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -39,17 +39,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [])
 
   const login = async (username: string, password: string) => {
-    const response = await authService.login({ username, password })
-    authService.saveToken(response.token)
-    authService.saveUser(response.user)
-    setUser(response.user)
+    const { token, user: authenticatedUser } = await authService.login({ username, password })
+    authService.saveToken(token)
+    authService.saveUser(authenticatedUser)
+    setUser(authenticatedUser)
   }
 
   const register = async (username: string, password: string) => {
-    const response = await authService.register({ username, password })
-    authService.saveToken(response.token)
-    authService.saveUser(response.user)
-    setUser(response.user)
+    const { token, user: registeredUser } = await authService.register({ username, password })
+    authService.saveToken(token)
+    authService.saveUser(registeredUser)
+    setUser(registeredUser)
   }
 
   const logout = () => {

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,15 +1,15 @@
 import { authApi } from './api'
-import type { AuthResponse, LoginRequest, RegisterRequest, User } from '../types'
+import type { AuthData, AuthResponse, LoginRequest, RegisterRequest, User } from '../types'
 
 export const authService = {
-  async login(credentials: LoginRequest): Promise<AuthResponse> {
-    const response = await authApi.post<AuthResponse>('/api/auth/login', credentials)
-    return response.data
+  async login(credentials: LoginRequest): Promise<AuthData> {
+    const { data: responseData } = await authApi.post<AuthResponse>('/api/auth/login', credentials)
+    return responseData.data
   },
 
-  async register(userData: RegisterRequest): Promise<AuthResponse> {
-    const response = await authApi.post<AuthResponse>('/api/auth/register', userData)
-    return response.data
+  async register(userData: RegisterRequest): Promise<AuthData> {
+    const { data: responseData } = await authApi.post<AuthResponse>('/api/auth/register', userData)
+    return responseData.data
   },
 
   async getProfile(): Promise<User> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,9 +6,16 @@ export interface User {
   createdAt: string
 }
 
-export interface AuthResponse {
+export interface AuthData {
   token: string
   user: User
+}
+
+export interface AuthResponse {
+  success: boolean
+  message: string
+  data: AuthData
+  timestamp: string
 }
 
 export interface LoginRequest {


### PR DESCRIPTION
## Summary
- unwrap the auth API response so login/register return token and user data
- update auth response typings and useAuth state handling to match the normalized payload
- remove unused imports flagged by the TypeScript build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98757d0fc832db71189e07e5c4101