### PR TITLE
Add loading state management to auth hook operations

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -39,22 +39,38 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [])
 
   const login = async (username: string, password: string) => {
-    const { token, user: authenticatedUser } = await authService.login({ username, password })
-    authService.saveToken(token)
-    authService.saveUser(authenticatedUser)
-    setUser(authenticatedUser)
+    setIsLoading(true)
+    try {
+      const { token, user: authenticatedUser } = await authService.login({ username, password })
+      authService.saveToken(token)
+      authService.saveUser(authenticatedUser)
+      setUser(authenticatedUser)
+      setIsLoading(false)
+    } catch (error) {
+      setIsLoading(false)
+      throw error
+    }
   }
 
   const register = async (username: string, password: string) => {
-    const { token, user: registeredUser } = await authService.register({ username, password })
-    authService.saveToken(token)
-    authService.saveUser(registeredUser)
-    setUser(registeredUser)
+    setIsLoading(true)
+    try {
+      const { token, user: registeredUser } = await authService.register({ username, password })
+      authService.saveToken(token)
+      authService.saveUser(registeredUser)
+      setUser(registeredUser)
+      setIsLoading(false)
+    } catch (error) {
+      setIsLoading(false)
+      throw error
+    }
   }
 
   const logout = () => {
+    setIsLoading(true)
     authService.logout()
     setUser(null)
+    setIsLoading(false)
   }
 
   return (


### PR DESCRIPTION
## Summary
- set the loading indicator at the beginning of login, register, and logout actions
- ensure the loading state is cleared once authentication updates complete or error

## Testing
- npm run lint *(fails: ESLint configuration file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c98efb427c832d9c82526e51319e1b